### PR TITLE
Mute Style/StringLiterals cop.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,9 @@ Style/RaiseArgs:
 Style/SignalException:
   Enabled: false
 
+Style/StringLiterals:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 20
 


### PR DESCRIPTION
Don't checks uses of quotes(single vs double quotes).

For more specifics of the cop, see https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringLiterals.