### PR TITLE
Disable few rubocop "Style" cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,16 +88,13 @@ Metrics/MethodLength:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Style/SingleLineBlockParams:
-  Enabled: false
-
 Style/FormatString:
   Enabled: false
 
-Style/WordArray:
+Style/RedundantSelf:
   Enabled: false
 
-Style/RedundantSelf:
+Style/SingleLineBlockParams:
   Enabled: false
 
 Style/StringLiteralsInInterpolation:
@@ -105,3 +102,7 @@ Style/StringLiteralsInInterpolation:
 
 Style/TrivialAccessors:
   AllowPredicates: true
+
+Style/WordArray:
+  Enabled: false
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,6 +85,9 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 15
 
+Style/ClassAndModuleChildren:
+  Enabled: false
+
 Style/SingleLineBlockParams:
   Enabled: false
 
@@ -95,6 +98,9 @@ Style/WordArray:
   Enabled: false
 
 Style/RedundantSelf:
+  Enabled: false
+
+Style/StringLiteralsInInterpolation:
   Enabled: false
 
 Style/TrivialAccessors:


### PR DESCRIPTION
Disabled the following two cops: 
 - https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ClassAndModuleChildren
 - https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringLiteralsInInterpolation

Also, shuffled a few rules to maintain lexical ordering.